### PR TITLE
Modernized backgrounds and seperators

### DIFF
--- a/common/src/main/java/org/thinkingstudio/obsidianui/util/RenderUtil.java
+++ b/common/src/main/java/org/thinkingstudio/obsidianui/util/RenderUtil.java
@@ -63,6 +63,7 @@ public final class RenderUtil {
 		int right = x + width;
 		int bottom = y + height;
 
+		RenderSystem.enableBlend();
 		bufferBuilder.vertex(x, bottom, 0)
 				.texture(0, bottom / 32.f + vOffset)
 				.color(red, green, blue, alpha);
@@ -76,6 +77,7 @@ public final class RenderUtil {
 				.texture(0, y / 32.f + vOffset)
 				.color(red, green, blue, alpha);
 		BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+		RenderSystem.disableBlend();
 	}
 
 	/**

--- a/common/src/main/java/org/thinkingstudio/obsidianui/util/RenderUtil.java
+++ b/common/src/main/java/org/thinkingstudio/obsidianui/util/RenderUtil.java
@@ -11,7 +11,7 @@
 package org.thinkingstudio.obsidianui.util;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
 import net.minecraft.util.Identifier;
 
@@ -20,6 +20,9 @@ public final class RenderUtil {
 	 * The dirt background texture used in 1.20.5 and above versions.
 	 */
 	public static final Identifier DIRT_BACKGROUND_TEXTURE = Identifier.of("obsidianui", "textures/gui/dirt_background.png");
+	private static final Identifier MENU_LIST_BACKGROUND_TEXTURE = Identifier.ofVanilla("textures/gui/menu_list_background.png");
+	private static final Identifier INWORLD_MENU_LIST_BACKGROUND_TEXTURE = Identifier.ofVanilla("textures/gui/inworld_menu_list_background.png");
+	private static final MinecraftClient client = MinecraftClient.getInstance();
 
 	private RenderUtil() {
 		throw new IllegalStateException("RenderUtil only contains static-definitions.");
@@ -58,7 +61,7 @@ public final class RenderUtil {
 		var bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
 		RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
 		RenderSystem.setShaderColor(1.f, 1.f, 1.f, 1.f);
-		RenderSystem.setShaderTexture(0, Screen.MENU_BACKGROUND_TEXTURE);
+		RenderSystem.setShaderTexture(0, getListBackgroundTexture());
 
 		int right = x + width;
 		int bottom = y + height;
@@ -78,6 +81,9 @@ public final class RenderUtil {
 				.color(red, green, blue, alpha);
 		BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
 		RenderSystem.disableBlend();
+	}
+	public static Identifier getListBackgroundTexture() {
+		return client.world == null ? MENU_LIST_BACKGROUND_TEXTURE : INWORLD_MENU_LIST_BACKGROUND_TEXTURE;
 	}
 
 	/**

--- a/common/src/main/java/org/thinkingstudio/obsidianui/widget/container/SpruceEntryListWidget.java
+++ b/common/src/main/java/org/thinkingstudio/obsidianui/widget/container/SpruceEntryListWidget.java
@@ -11,7 +11,6 @@
 package org.thinkingstudio.obsidianui.widget.container;
 
 import com.google.common.collect.Lists;
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -20,6 +19,7 @@ import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
 import net.minecraft.client.render.*;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
@@ -37,6 +37,11 @@ import org.thinkingstudio.obsidianui.widget.WithBorder;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.List;
+
+import static net.minecraft.client.gui.screen.Screen.HEADER_SEPARATOR_TEXTURE;
+import static net.minecraft.client.gui.screen.Screen.FOOTER_SEPARATOR_TEXTURE;
+import static net.minecraft.client.gui.screen.Screen.INWORLD_HEADER_SEPARATOR_TEXTURE;
+import static net.minecraft.client.gui.screen.Screen.INWORLD_FOOTER_SEPARATOR_TEXTURE;
 
 /**
  * Represents an entry list.
@@ -323,6 +328,11 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 	protected void renderBackground(DrawContext drawContext, int mouseX, int mouseY, float delta) {
 		this.getBackground().render(drawContext, this, 0, mouseX, mouseY, delta);
 	}
+	protected Identifier getSeparatorTexture(boolean header) {
+		boolean isIngame = this.client.world != null;
+		if (header) return isIngame ? INWORLD_HEADER_SEPARATOR_TEXTURE : HEADER_SEPARATOR_TEXTURE;
+		else return isIngame ? INWORLD_FOOTER_SEPARATOR_TEXTURE : FOOTER_SEPARATOR_TEXTURE;
+	}
 
 	@Override
 	protected void renderWidget(DrawContext drawContext, int mouseX, int mouseY, float delta) {
@@ -337,42 +347,25 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 		this.entries.forEach(e -> e.render(drawContext, mouseX, mouseY, delta));
 		ScissorManager.pop();
 
-		var tessellator = Tessellator.getInstance();
-		var buffer = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
+
+		RenderSystem.enableBlend();
 		// Render the transition thingy.
 		if (this.shouldRenderTransition()) {
-			RenderSystem.enableBlend();
-			RenderSystem.blendFuncSeparate(
-					GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-					GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-			);
-			RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-			// TOP
-			buffer.vertex(left, top + 4, 0).color(0, 0, 0, 0);
-			buffer.vertex(right, top + 4, 0).color(0, 0, 0, 0);
-			buffer.vertex(right, top, 0).color(0, 0, 0, 255);
-			buffer.vertex(left, top, 0).color(0, 0, 0, 255);
-			// RIGHT
-			buffer.vertex(right - 4, bottom, 0).color(0, 0, 0, 0);
-			buffer.vertex(right, bottom, 0).color(0, 0, 0, 255);
-			buffer.vertex(right, top, 0).color(0, 0, 0, 255);
-			buffer.vertex(right - 4, top, 0).color(0, 0, 0, 0);
-			// BOTTOM
-			buffer.vertex(left, bottom, 0).color(0, 0, 0, 255);
-			buffer.vertex(right, bottom, 0).color(0, 0, 0, 255);
-			buffer.vertex(right, bottom - 4, 0).color(0, 0, 0, 0);
-			buffer.vertex(left, bottom - 4, 0).color(0, 0, 0, 0);
-			// LEFT
-			buffer.vertex(left, bottom, 0).color(0, 0, 0, 255);
-			buffer.vertex(left + 4, bottom, 0).color(0, 0, 0, 0);
-			buffer.vertex(left + 4, top, 0).color(0, 0, 0, 0);
-			buffer.vertex(left, top, 0).color(0, 0, 0, 255);
-			BufferRenderer.drawWithGlobalProgram(buffer.end());
+			Identifier topTexture = getSeparatorTexture(true);
+			Identifier bottomTexture = getSeparatorTexture(false);
+
+			drawContext.drawTexture(topTexture, left, top - 2, 0.0F, 0.0F, this.getWidth(), 2, 32, 2);
+			drawContext.drawTexture(bottomTexture, left, bottom, 0.0F, 0.0F, this.getWidth(), 2, 32, 2);
+			// The following code is absolutely cursed, but works surprisingly well to create side borders
+			int screenWidth = client.getWindow().getScaledWidth();
+			if (left > 0) drawContext.drawTexture(topTexture, left-1, top - 1, 0.0F, 0.0F, 1, this.getHeight() + 2, 1, (this.getHeight() + 2) * 2);
+			if (right < screenWidth) drawContext.drawTexture(topTexture, right, top - 1, 0.0F, 0.0F, 1, this.getHeight() + 2, 1, (this.getHeight() + 2) * 2);
 		}
 
 		// Scrollbar
 		int maxScroll = this.getMaxScroll();
 		if (maxScroll > 0) {
+			var tessellator = Tessellator.getInstance();
 			int scrollbarHeight = (int) ((float) ((this.getHeight()) * (this.getHeight())) / (float) this.getMaxPosition());
 			scrollbarHeight = MathHelper.clamp(scrollbarHeight, 32, this.getHeight() - 8);
 			int scrollbarY = (int) this.getScrollAmount() * (this.getHeight() - scrollbarHeight) / maxScroll + this.getY();

--- a/common/src/main/java/org/thinkingstudio/obsidianui/widget/container/SpruceEntryListWidget.java
+++ b/common/src/main/java/org/thinkingstudio/obsidianui/widget/container/SpruceEntryListWidget.java
@@ -380,7 +380,7 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 				scrollbarY = this.getY();
 			}
 
-			this.renderScrollbar(tessellator, buffer, scrollbarPositionX, scrollBarEnd, scrollbarY, scrollbarHeight);
+			this.renderScrollbar(tessellator, scrollbarPositionX, scrollBarEnd, scrollbarY, scrollbarHeight);
 		}
 
 		this.getBorder().render(drawContext, this, mouseX, mouseY, delta);
@@ -388,10 +388,10 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 		RenderSystem.disableBlend();
 	}
 
-	protected void renderScrollbar(Tessellator tessellator, BufferBuilder buffer, int scrollbarX, int scrollbarEndX, int scrollbarY, int scrollbarHeight) {
+	protected void renderScrollbar(Tessellator tessellator, int scrollbarX, int scrollbarEndX, int scrollbarY, int scrollbarHeight) {
 		RenderSystem.setShader(GameRenderer::getPositionColorProgram);
 
-		//tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
+		BufferBuilder buffer = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
 		buffer.vertex(scrollbarX, this.getY() + this.getHeight(), 0).color(0, 0, 0, 255);
 		buffer.vertex(scrollbarEndX, this.getY() + this.getHeight(), 0).color(0, 0, 0, 255);
 		buffer.vertex(scrollbarEndX, this.getY(), 0).color(0, 0, 0, 255);

--- a/test-fabric/src/main/java/org/thinkingstudio/obsidianui/test/fabric/mixin/GameMenuScreenMixin.java
+++ b/test-fabric/src/main/java/org/thinkingstudio/obsidianui/test/fabric/mixin/GameMenuScreenMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020 LambdAurora <email@lambdaurora.dev>
+ *
+ * This file is part of SpruceUI.
+ *
+ * Licensed under the MIT license. For more information,
+ * see the LICENSE file.
+ */
+
+package org.thinkingstudio.obsidianui.test.fabric.mixin;
+
+import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.thinkingstudio.obsidianui.Position;
+import org.thinkingstudio.obsidianui.test.fabric.gui.SpruceMainMenuScreen;
+import org.thinkingstudio.obsidianui.widget.SpruceButtonWidget;
+
+@Mixin(GameMenuScreen.class)
+public class GameMenuScreenMixin extends Screen {
+	protected GameMenuScreenMixin(Text title) {
+		super(title);
+	}
+
+	@Inject(method = "init", at = @At("RETURN"))
+	private void onInit(CallbackInfo ci) {
+		this.addDrawableChild(new SpruceButtonWidget(Position.of(0, 0), 150, 20, Text.literal("ObsidianUI Test Menu"),
+				btn -> this.client.setScreen(new SpruceMainMenuScreen(this))).asVanilla());
+	}
+}

--- a/test-fabric/src/main/resources/obsidianui.test.fabric.mixins.json
+++ b/test-fabric/src/main/resources/obsidianui.test.fabric.mixins.json
@@ -3,6 +3,7 @@
   "package": "org.thinkingstudio.obsidianui.test.fabric.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "GameMenuScreenMixin",
     "TitleScreenMixin"
   ],
   "injectors": {

--- a/test-neoforge/src/main/java/org/thinkingstudio/obsidianui/test/neoforge/mixin/GameMenuScreenMixin.java
+++ b/test-neoforge/src/main/java/org/thinkingstudio/obsidianui/test/neoforge/mixin/GameMenuScreenMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020 LambdAurora <email@lambdaurora.dev>
+ *
+ * This file is part of SpruceUI.
+ *
+ * Licensed under the MIT license. For more information,
+ * see the LICENSE file.
+ */
+
+package org.thinkingstudio.obsidianui.test.neoforge.mixin;
+
+import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.thinkingstudio.obsidianui.Position;
+import org.thinkingstudio.obsidianui.test.neoforge.gui.SpruceMainMenuScreen;
+import org.thinkingstudio.obsidianui.widget.SpruceButtonWidget;
+
+@Mixin(GameMenuScreen.class)
+public class GameMenuScreenMixin extends Screen {
+	protected GameMenuScreenMixin(Text title) {
+		super(title);
+	}
+
+	@Inject(method = "init", at = @At("RETURN"))
+	private void onInit(CallbackInfo ci) {
+		this.addDrawableChild(new SpruceButtonWidget(Position.of(0, 0), 150, 20, Text.literal("ObsidianUI Test Menu"),
+				btn -> this.client.setScreen(new SpruceMainMenuScreen(this))).asVanilla());
+	}
+}

--- a/test-neoforge/src/main/resources/obsidianui.test.neoforge.mixins.json
+++ b/test-neoforge/src/main/resources/obsidianui.test.neoforge.mixins.json
@@ -3,6 +3,7 @@
   "package": "org.thinkingstudio.obsidianui.test.neoforge.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "GameMenuScreenMixin",
     "TitleScreenMixin"
   ],
   "injectors": {


### PR DESCRIPTION
- The list background now follows the one in vanilla screens and changes when in-game
- The bottom/top/side background separator now follows the new style introduced in 1.20.5 -> Also improves accessibility with High Contrast Resourcepack
- Development: Added test buttons to pause menu to preview in-game appearance

![Bildschirmfoto vom 2024-06-18 12-23-50](https://github.com/ThinkingStudios/ObsidianUI/assets/49783724/929a4a18-a25f-4ee2-87a1-690f41401bb9)

This PR also contains my 1.21 improvements, merge this PR instead of the other one to avoid merge conflicts.